### PR TITLE
The posterior sampling seems to had never been performed in the LDpred.py

### DIFF
--- a/ldpred/LDpred.py
+++ b/ldpred/LDpred.py
@@ -329,7 +329,7 @@ def ldpred_gibbs(beta_hats, genotypes=None, start_betas=None, h2=None, n=1000, l
         alpha = min(1 - zero_jump_prob, 1.0 / h2_est, (h2 + 1 / sp.sqrt(n)) / h2_est)
 
         rand_ps = sp.random.random(m)
-        rand_norms = stats.norm.rvs(0, (hdmp_hdmpn) * (1 / n), size=m)
+        rand_norms = stats.norm.rvs(0, (hdmp_hdmpn) * (1.0 / n), size=m)
 
         if ld_boundaries is None:
             for i, snp_i in enumerate(iter_order):


### PR DESCRIPTION
Integer division in python2 (when both arguments are integers) is the floor division. In a formula for a 'scale' argument of stats.norm.rvs:
https://github.com/bvilhjal/ldpred/blob/8a2f5153b20c1da6801bf7e86d44ffddd3b0c3be/ldpred/LDpred.py#L332
`1 / n` is calculated. n is a number of samples, explicitly casted to integer at: 
https://github.com/bvilhjal/ldpred/blob/8a2f5153b20c1da6801bf7e86d44ffddd3b0c3be/ldpred/LDpred.py#L87
Therefore, the formula always evaluates to 0, and `rand_norms == np.zeros(m, dtype=float)`. It is the only place in code, where rand_norms values are assigned, and according to a comment, it is supposed to be used for:
https://github.com/bvilhjal/ldpred/blob/8a2f5153b20c1da6801bf7e86d44ffddd3b0c3be/ldpred/LDpred.py#L367-L368
Thus, I have a feeling, that no sampling had actually been performed by the existing version of code (`rand_norms[i]` was always 0). I do not know, whether this bug heavily changes calculated betas, since the correctly calculated 'scale' argument is still around ~10⁻⁸.