### PR TITLE
Make all unit tests pass on Windows

### DIFF
--- a/ldpred/LD_pruning_thres.py
+++ b/ldpred/LD_pruning_thres.py
@@ -168,7 +168,7 @@ def ld_pruning(data_file=None, ld_radius = None, out_file_prefix=None, p_thres=N
         
         weights_out_file = '%s_P+T_r%0.2f_p%0.4e.txt'%(out_file_prefix, max_r2, p_thres)
         
-        with open(weights_out_file,'w') as f:
+        with open(weights_out_file, 'w', newline="\n") as f:
             f.write('chrom    pos    sid    nt1    nt2    raw_beta    raw_pval_beta    updated_beta    updated_pval_beta \n')
             for chrom, pos, sid, nt, raw_beta, raw_pval_beta, upd_beta, upd_pval_beta in zip(chromosomes, positions, sids, nts, raw_effect_sizes, raw_pval_effect_sizes, updated_effect_sizes, updated_pval_effect_sizes):
                 nt1,nt2 = nt[0],nt[1]

--- a/ldpred/LDpred_fast.py
+++ b/ldpred/LDpred_fast.py
@@ -95,7 +95,7 @@ def write_res_dict_2_file(out_file_prefix, results_cdict, ps):
     for p_c in ps:
         p_str = '%0.4f' % p_c
         weights_out_file = '%s_LDpred_fast_p%0.4e.txt' % (out_file_prefix, p_c)
-        with open(weights_out_file, 'w') as f:
+        with open(weights_out_file, 'w', newline="\n") as f:
             f.write('chrom    pos    sid    nt1    nt2    raw_beta     ldpred_beta\n')
             for chrom_str in util.chromosomes_list:
                 if chrom_str in results_cdict:

--- a/ldpred/LDpred_gibbs.py
+++ b/ldpred/LDpred_gibbs.py
@@ -375,14 +375,14 @@ def ldpred_genomewide(data_file=None, ld_radius=None, ld_dict=None, out_file_pre
             
         
         weights_out_file = '%s_LDpred_p%0.4e.txt' % (out_file_prefix, p)
-        with open(weights_out_file, 'w') as f:
+        with open(weights_out_file, 'w', newline="\n") as f:
             f.write('chrom    pos    sid    nt1    nt2    raw_beta     ldpred_beta\n')
             for chrom, pos, sid, nt, raw_beta, ldpred_beta in zip(chromosomes, out_positions, out_sids, out_nts, raw_effect_sizes, ldpred_effect_sizes):
                 nt1, nt2 = nt[0], nt[1]
                 f.write('%s    %d    %s    %s    %s    %0.4e    %0.4e\n' % (chrom, pos, sid, nt1, nt2, raw_beta, ldpred_beta))
 
     weights_out_file = '%s_LDpred-inf.txt' % (out_file_prefix)
-    with open(weights_out_file, 'w') as f:
+    with open(weights_out_file, 'w', newline="\n") as f:
         f.write('chrom    pos    sid    nt1    nt2    raw_beta    ldpred_inf_beta \n')
         for chrom, pos, sid, nt, raw_beta, ldpred_inf_beta in zip(chromosomes, out_positions, out_sids, out_nts, raw_effect_sizes, ldpred_inf_effect_sizes):
             nt1, nt2 = nt[0], nt[1]

--- a/ldpred/LDpred_inf.py
+++ b/ldpred/LDpred_inf.py
@@ -155,7 +155,7 @@ def ldpred_inf_genomewide(data_file=None, ld_radius = None, ld_dict=None, out_fi
         results_dict['slope_pd']=regression_slope
     
     weights_out_file = '%s_LDpred-inf.txt' % (out_file_prefix)
-    with open(weights_out_file,'w') as f:
+    with open(weights_out_file, 'w', newline="\n") as f:
         f.write('chrom    pos    sid    nt1    nt2    raw_beta    ldpred_inf_beta\n')
         for chrom, pos, sid, nt, raw_beta, ldpred_beta in zip(chromosomes, positions, sids, nts, raw_effect_sizes, ldpred_effect_sizes):
             nt1,nt2 = nt[0],nt[1]

--- a/ldpred/coord_genotypes.py
+++ b/ldpred/coord_genotypes.py
@@ -51,7 +51,7 @@ def write_coord_data(cord_data_g, coord_dict, debug=False):
         ofg.create_dataset('log_odds_prs', data=coord_dict['log_odds_prs'])
 
     ofg.create_dataset('ps', data=coord_dict['ps'])
-    ofg.create_dataset('positions', data=coord_dict['positions'])
+    ofg.create_dataset('positions', data=coord_dict['positions'], dtype='int64')
     ofg.create_dataset('nts', data=sp.array(coord_dict['nts'],dtype=util.nts_dtype))
     ofg.create_dataset('sids', data=sp.array(coord_dict['sids'],dtype=util.sids_dtype))
     ofg.create_dataset('betas', data=coord_dict['betas'])

--- a/ldpred/sum_stats_parsers.py
+++ b/ldpred/sum_stats_parsers.py
@@ -423,10 +423,10 @@ def parse_sum_stats_custom(filename=None, bimfile=None, only_hm3=False, hdf5_fil
         g.create_dataset('betas', data=betas)
         g.create_dataset('log_odds', data=log_odds)
         num_snps += len(log_odds)
-        g.create_dataset('infos', data=infos)
+        g.create_dataset('infos', data=infos, dtype='int64')
         g.create_dataset('nts', data=nts)
         g.create_dataset('sids', data=sids)
-        g.create_dataset('positions', data=positions)
+        g.create_dataset('positions', data=positions, dtype='int64')
         g.create_dataset('ns', data=ns)
         hdf5_file.flush()
     

--- a/ldpred/validate.py
+++ b/ldpred/validate.py
@@ -319,7 +319,7 @@ def parse_pt_res(file_name):
 def write_scores_file(out_file, prs_dict, pval_derived_effects_prs, adj_pred_dict, 
                       output_regression_betas=False, weights_dict=None, verbose=False):
     num_individs = len(prs_dict['iids'])
-    with open(out_file, 'w') as f:
+    with open(out_file, 'w', newline="\n") as f:
         if verbose:
             print ('Writing polygenic scores to file %s'%out_file)
         out_str = 'IID, true_phens, PRS'
@@ -343,7 +343,7 @@ def write_scores_file(out_file, prs_dict, pval_derived_effects_prs, adj_pred_dic
             f.write(out_str)
 
     if len(list(adj_pred_dict.keys())) > 0:
-        with open(out_file + '.adj', 'w') as f:
+        with open(out_file + '.adj', 'w', newline="\n") as f:
             adj_prs_labels = list(adj_pred_dict.keys())
             out_str = 'IID, true_phens, PRS, ' + \
                 ', '.join(adj_prs_labels)
@@ -370,7 +370,7 @@ def write_scores_file(out_file, prs_dict, pval_derived_effects_prs, adj_pred_dic
 
 def write_only_scores_file(out_file, prs_dict, pval_derived_effects_prs):
     num_individs = len(prs_dict['iids'])
-    with open(out_file, 'w') as f:
+    with open(out_file, 'w', newline="\n") as f:
         print ('Writing polygenic scores to file %s'%out_file)
         out_str = 'IID, PRS \n'
         f.write(out_str)
@@ -763,7 +763,7 @@ def main(p_dict):
 
     res_summary_file = p_dict['summary_file']
     if res_summary_file is not None and not p_dict['only_score']:
-        with open(res_summary_file,'w') as f:
+        with open(res_summary_file, 'w', newline="\n") as f:
             if verbose:
                 print ('Writing Results Summary to file %s'%res_summary_file)
             out_str = 'Pred_Method    Pred_corr    Pred_R2    SNPs_used\n'

--- a/tests/test.py
+++ b/tests/test.py
@@ -23,9 +23,15 @@ import os
 import tempfile
 import unittest
 import sys
+import glob
 
 np.set_printoptions(linewidth=int(os.environ.get('COLUMNS', 100)))
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+
+def remove_files_with_prefix(prefix):
+    for file in glob.glob('%s*' % prefix):
+	    if os.path.isfile(file):
+	        os.remove(file)
 
 def run_test(mesg, cmd_str, error_mesg, *actual_and_golden_outputs):
     print(mesg)
@@ -173,7 +179,7 @@ class SimpleTests(unittest.TestCase):
         print('Cleaning up files: %s* ' % self.tmp_file_prefix)
         cmd_str = 'rm -f %s*' % self.tmp_file_prefix
         print(cmd_str + '\n')
-        assert os.system(cmd_str) == 0, 'Problems cleaning up test files!  Testing stopped'
+        remove_files_with_prefix(self.tmp_file_prefix)
 
     def test_parse_sum_stats(self):
         p_dict = {
@@ -364,7 +370,7 @@ class ComplexTests(unittest.TestCase):
         print('Cleaning up files: %s* ' % self.tmp_file_prefix)
         cmd_str = 'rm -f %s*' % self.tmp_file_prefix
         print(cmd_str + '\n')
-        assert os.system(cmd_str) == 0, 'Problems cleaning up test files!  Testing stopped'
+        remove_files_with_prefix(self.tmp_file_prefix)
 
     def test_mix1(self):
         t_i = 0
@@ -495,7 +501,7 @@ def update_golden_files_mix1():
         print('Cleaning up files.')
         cmd_str = 'rm %s*' % tmp_file_prefix
         print(cmd_str + '\n')
-        assert os.system(cmd_str) == 0, 'Problems cleaning up test files!  Testing stopped'
+        remove_files_with_prefix(tmp_file_prefix)
 
 def update_golden_files_mix2():
     label = 'mix2'
@@ -533,7 +539,7 @@ def update_golden_files_mix2():
         print('Cleaning up files.')
         cmd_str = 'rm %s*' % tmp_file_prefix
         print(cmd_str + '\n')
-        assert os.system(cmd_str) == 0, 'Problems cleaning up test files!  Testing stopped'
+        remove_files_with_prefix(tmp_file_prefix)
 
 
 


### PR DESCRIPTION
Make file outputs on Windows the same as GNU/Linux
by setting the arguments of output methods explicitly
in order to make all unit tests pass.